### PR TITLE
[Tag] Adds type=button attribute to Clickable Tag

### DIFF
--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -61,7 +61,7 @@ export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
   ) : null;
 
   const tagMarkup = onClick ? (
-    <button disabled={disabled} className={className} onClick={onClick}>
+    <button type="button" disabled={disabled} className={className} onClick={onClick}>
       {children}
     </button>
   ) : (


### PR DESCRIPTION
Adds type=button attribute to Clickable Tag.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

https://github.com/Shopify/polaris-react/issues/2894
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adding `type="button"` attribute to Clickable Tag component.